### PR TITLE
feat(health): 健康/就绪探针与 OSS 连接性监控集成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ Thumbs.db
 # Dependency managers
 node_modules/
 vendor/
+
+# 临时控制git
+web/
+go.mod
+go.sum

--- a/core/core.go
+++ b/core/core.go
@@ -83,11 +83,12 @@ func main() {
 		ok   bool
 		err  error
 	}
-	ch := make(chan res, 3)
+    ch := make(chan res, 4)
 	go func() { err := ctx.DBEngine.Ping(); ch <- res{"database", err == nil, err} }()
 	go func() { err := ctx.RedisClient.Ping(checkCtx).Err(); ch <- res{"redis", err == nil, err} }()
 	go func() { err := utils.EmailConnectivity(checkCtx); ch <- res{"email", err == nil, err} }()
-	for i := 0; i < 3; i++ {
+    go func() { err := utils.OSSConnectivity(checkCtx); ch <- res{"oss", err == nil, err} }()
+    for i := 0; i < 4; i++ {
 		r := <-ch
 		if r.ok {
 			logx.Infof("startup %s ok", r.name)

--- a/core/core.go
+++ b/core/core.go
@@ -8,11 +8,20 @@ import (
 	"cloud_disk/core/internal/config"
 	"cloud_disk/core/internal/handler"
 	"cloud_disk/core/internal/svc"
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
+	"cloud_disk/core/utils"
+
+	"github.com/joho/godotenv"
 	"github.com/zeromicro/go-zero/core/conf"
+	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/rest"
 	"github.com/zeromicro/go-zero/rest/httpx"
 )
@@ -22,14 +31,73 @@ var configFile = flag.String("f", "core/etc/core-api.yaml", "the config file")
 func main() {
 	flag.Parse()
 
+	_ = godotenv.Load(".env")
+	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+	case "debug":
+		logx.SetLevel(logx.DebugLevel)
+	case "error":
+		logx.SetLevel(logx.ErrorLevel)
+	case "severe":
+		logx.SetLevel(logx.SevereLevel)
+	default:
+		logx.SetLevel(logx.InfoLevel)
+	}
+
 	var c config.Config
 	conf.MustLoad(*configFile, &c)
+
+	if os.Getenv("DB_HOST") != "" {
+		host := os.Getenv("DB_HOST")
+		port := os.Getenv("DB_PORT")
+		user := os.Getenv("DB_USER")
+		pass := os.Getenv("DB_PASSWORD")
+		name := os.Getenv("DB_NAME")
+		if host != "" && port != "" && user != "" && name != "" {
+			c.MySQL.DataSource = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True&loc=Local", user, pass, host, port, name)
+		}
+	}
+	if os.Getenv("REDIS_HOST") != "" {
+		rhost := os.Getenv("REDIS_HOST")
+		rport := os.Getenv("REDIS_PORT")
+		rpass := os.Getenv("REDIS_PASSWORD")
+		rdbStr := os.Getenv("REDIS_DB")
+		c.Redis.Addr = fmt.Sprintf("%s:%s", rhost, rport)
+		c.Redis.Password = rpass
+		if rdbStr != "" {
+			if v, err := strconv.Atoi(rdbStr); err == nil {
+				c.Redis.DB = v
+			}
+		}
+	}
 
 	server := rest.MustNewServer(c.RestConf, rest.WithUnauthorizedCallback(JwtUnauthorizedResult))
 	defer server.Stop()
 
 	ctx := svc.NewServiceContext(c)
 	handler.RegisterHandlers(server, ctx)
+
+	checkCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	type res struct {
+		name string
+		ok   bool
+		err  error
+	}
+	ch := make(chan res, 3)
+	go func() { err := ctx.DBEngine.Ping(); ch <- res{"database", err == nil, err} }()
+	go func() { err := ctx.RedisClient.Ping(checkCtx).Err(); ch <- res{"redis", err == nil, err} }()
+	go func() { err := utils.EmailConnectivity(checkCtx); ch <- res{"email", err == nil, err} }()
+	for i := 0; i < 3; i++ {
+		r := <-ch
+		if r.ok {
+			logx.Infof("startup %s ok", r.name)
+		} else {
+			logx.Infof("startup %s failed", r.name)
+			if r.err != nil {
+				logx.Errorf("startup %s error: %v", r.name, r.err)
+			}
+		}
+	}
 
 	fmt.Printf("Starting server at %s:%d...\n", c.Host, c.Port)
 	server.Start()

--- a/core/internal/handler/health_handler.go
+++ b/core/internal/handler/health_handler.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"net/http"
+
+	"cloud_disk/core/internal/svc"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func HealthHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		httpx.WriteJson(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}

--- a/core/internal/handler/ready_handler.go
+++ b/core/internal/handler/ready_handler.go
@@ -1,49 +1,38 @@
 package handler
 
 import (
-	"context"
-	"net/http"
-	"time"
-
-	"cloud_disk/core/internal/svc"
-
-	"github.com/zeromicro/go-zero/rest/httpx"
+  "cloud_disk/core/internal/svc"
+  "cloud_disk/core/utils"
+  "context"
+  "net/http"
+  "time"
+  "github.com/zeromicro/go-zero/rest/httpx"
 )
 
 func ReadyHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodHead {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
-		defer cancel()
-		dbOk := true
-		if svcCtx.DBEngine != nil {
-			if err := svcCtx.DBEngine.Ping(); err != nil {
-				dbOk = false
-			}
-		} else {
-			dbOk = false
-		}
-		redisOk := true
-		if svcCtx.RedisClient != nil {
-			if err := svcCtx.RedisClient.Ping(ctx).Err(); err != nil {
-				redisOk = false
-			}
-		} else {
-			redisOk = false
-		}
-		status := "ready"
-		if !dbOk || !redisOk {
-			status = "degraded"
-		}
-		httpx.WriteJson(w, http.StatusOK, map[string]interface{}{
-			"status": status,
-			"checks": map[string]interface{}{
-				"database": map[string]bool{"ok": dbOk},
-				"redis":    map[string]bool{"ok": redisOk},
-			},
-		})
-	}
+  return func(w http.ResponseWriter, r *http.Request) {
+    ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+    defer cancel()
+    dbErr := svcCtx.DBEngine.Ping()
+    redisErr := svcCtx.RedisClient.Ping(ctx).Err()
+    ossErr := utils.OSSConnectivity(ctx)
+    ready := dbErr == nil && redisErr == nil && ossErr == nil
+    if r.Method == http.MethodHead {
+      if ready {
+        w.WriteHeader(http.StatusNoContent)
+      } else {
+        w.WriteHeader(http.StatusServiceUnavailable)
+      }
+      return
+    }
+    if ready {
+      httpx.WriteJson(w, http.StatusOK, map[string]any{"ready": true})
+      return
+    }
+    httpx.WriteJson(w, http.StatusServiceUnavailable, map[string]any{
+      "ready":  false,
+      "errors": map[string]any{"database": dbErr, "redis": redisErr, "oss": ossErr},
+    })
+  }
 }
+

--- a/core/internal/handler/ready_handler.go
+++ b/core/internal/handler/ready_handler.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"cloud_disk/core/internal/svc"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func ReadyHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		dbOk := true
+		if svcCtx.DBEngine != nil {
+			if err := svcCtx.DBEngine.Ping(); err != nil {
+				dbOk = false
+			}
+		} else {
+			dbOk = false
+		}
+		redisOk := true
+		if svcCtx.RedisClient != nil {
+			if err := svcCtx.RedisClient.Ping(ctx).Err(); err != nil {
+				redisOk = false
+			}
+		} else {
+			redisOk = false
+		}
+		status := "ready"
+		if !dbOk || !redisOk {
+			status = "degraded"
+		}
+		httpx.WriteJson(w, http.StatusOK, map[string]interface{}{
+			"status": status,
+			"checks": map[string]interface{}{
+				"database": map[string]bool{"ok": dbOk},
+				"redis":    map[string]bool{"ok": redisOk},
+			},
+		})
+	}
+}

--- a/core/internal/handler/routes.go
+++ b/core/internal/handler/routes.go
@@ -15,6 +15,30 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 	server.AddRoutes(
 		[]rest.Route{
 			{
+				Method:  http.MethodGet,
+				Path:    "/health",
+				Handler: HealthHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodHead,
+				Path:    "/health",
+				Handler: HealthHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodGet,
+				Path:    "/ready",
+				Handler: ReadyHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodHead,
+				Path:    "/ready",
+				Handler: ReadyHandler(serverCtx),
+			},
+		},
+	)
+	server.AddRoutes(
+		[]rest.Route{
+			{
 				Method:  http.MethodPost,
 				Path:    "/detail",
 				Handler: UserDetailHandler(serverCtx),

--- a/core/utils/email_send.go
+++ b/core/utils/email_send.go
@@ -1,41 +1,82 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/smtp"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/jordan-wright/email"
 )
 
-var password string
+var (
+	emailEnabled  bool
+	emailHost     string
+	emailPort     string
+	emailUser     string
+	emailPassword string
+)
 
 func init() {
-	err := godotenv.Load(".env")
-	if err != nil {
-		panic(err)
+	_ = godotenv.Load(".env")
+	switch strings.ToLower(os.Getenv("EMAIL_ENABLED")) {
+	case "false", "0", "off", "no":
+		emailEnabled = false
+	default:
+		emailEnabled = true
 	}
-	password = os.Getenv("QQ_MAIL_PASSWORD")
+	emailHost = os.Getenv("EMAIL_HOST")
+	emailPort = os.Getenv("EMAIL_PORT")
+	emailUser = os.Getenv("EMAIL_USER")
+	emailPassword = os.Getenv("EMAIL_PASSWORD")
 }
 
 func SendEmail(emailAddress, code string) error {
+	if !emailEnabled {
+		return nil
+	}
+	if emailHost == "" || emailPort == "" || emailUser == "" || emailPassword == "" {
+		return fmt.Errorf("email env missing")
+	}
 	e := email.NewEmail()
-	e.From = "Get <2477183238@qq.com>"
+	e.From = fmt.Sprintf("CloudDisk <%s>", emailUser)
 	e.To = []string{emailAddress}
 	//e.Bcc = []string{"test_bcc@example.com"}
 	//e.Cc = []string{"test_cc@example.com"}
 	e.Subject = "玺朽GO 邮箱Server"
 	//e.Text = []byte("Text Body is, of course, supported!")
 	e.HTML = []byte("你的验证码：<h1>" + code + "</h1>")
-	err := e.SendWithStartTLS("smtp.qq.com:587", smtp.PlainAuth("", "2477183238@qq.com", password, "smtp.qq.com"),
+	addr := fmt.Sprintf("%s:%s", emailHost, emailPort)
+	err := e.SendWithStartTLS(addr, smtp.PlainAuth("", emailUser, emailPassword, emailHost),
 		&tls.Config{
-			ServerName:         "smtp.qq.com",
+			ServerName:         emailHost,
 			InsecureSkipVerify: true,
 		})
 	if err != nil {
-		fmt.Println("发送邮件失败：", err)
+		return err
 	}
+	return nil
+}
+
+func EmailEnabled() bool { return emailEnabled }
+
+func EmailConnectivity(ctx context.Context) error {
+	if !emailEnabled {
+		return nil
+	}
+	if emailHost == "" || emailPort == "" || emailUser == "" || emailPassword == "" {
+		return fmt.Errorf("email env missing")
+	}
+	d := net.Dialer{Timeout: 2 * time.Second}
+	conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", emailHost, emailPort))
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
 	return nil
 }

--- a/core/utils/oss_connectivity.go
+++ b/core/utils/oss_connectivity.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"cloud_disk/core/common"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func OSSHost() string {
+	bucket := os.Getenv("OSS_BUCKET_NAME")
+	region := os.Getenv("OSS_REGION")
+	if bucket == "" {
+		bucket = common.OSSBucketName
+	}
+	if region == "" {
+		region = common.OSSRegion
+	}
+	return fmt.Sprintf("%s.%s.aliyuncs.com:443", bucket, region)
+}
+
+func OSSConnectivity(ctx context.Context) error {
+	d := net.Dialer{Timeout: 2 * time.Second}
+	conn, err := d.DialContext(ctx, "tcp", OSSHost())
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
+	return nil
+}


### PR DESCRIPTION
### 变更摘要

- 新增 /health 与 /ready 端点，支持 GET/HEAD 探针
- 启动阶段并行检查 database、redis、email、oss 并输出结构化日志
- 新增 OSS 连接性检测工具函数（按 .env 优先，缺省回退 common）
- 配置管理增强：支持通过 .env 覆盖 MySQL、Redis、邮件与日志级别
- 邮件模块加入连通性检测与可关闭开关（EMAIL_ENABLED）

### 背景/动机

- 统一服务健康与就绪信号，满足 K8s/容器编排的探针需求
- 将外部依赖（DB/Redis/Email/OSS）在启动与运行时显式校验，提升可观测性与可恢复性
- 通过环境变量使部署参数与代码解耦，支持多环境快速切换

### 技术细节

- 健康端点: health_handler.go
  - HEAD /health → 200；GET /health → 200 {status:"ok"}
- 就绪端点: ready_handler.go
  - 聚合 database、redis、oss（以及可扩展项）检查
  - HEAD /ready → 204(就绪) 或 503(不就绪)
  - GET /ready → 200/503，携带 {ready, errors:{database,redis,oss}}
- 启动检查: core.go
  - context.WithTimeout(3s) 并发四项检查并记录日志
- OSS检测: oss_connectivity.go
  - 目标地址 bucket.region.aliyuncs.com:443
  - 从 .env 读取 OSS_BUCKET_NAME/OSS_REGION，缺失则回退到 define.go
- 路由注册: routes.go

### 接口变更

- 新增
  - GET/HEAD /health
  - GET/HEAD /ready
- 响应示例
  - GET /ready → 200 {ready:true}
  - GET /ready → 503 {ready:false, errors:{database:..., redis:..., oss:...}}
  - HEAD /ready → 204 或 503

### 环境变量

- OSS_BUCKET_NAME、OSS_REGION
- DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME
- REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/REDIS_DB
- EMAIL_ENABLED、EMAIL_HOST、EMAIL_PORT、EMAIL_USER、EMAIL_PASSWORD
- LOG_LEVEL（debug/error/severe/info）

### 验证步骤

- 启动应用后观察日志：
  - 出现 “startup database/redis/email/oss ok” 或具体错误
- 探针验证：
  - curl -I http://<host_ip>:8888/health → 200
  - curl -I http://<host_ip>:8888/ready → 204 或 503
  - curl http://<host_ip>:8888/ready → 检查 JSON 中 errors 字段
- OSS 验证：
  - 在 core/.env 配置有效的 OSS_BUCKET_NAME 与 OSS_REGION
  - 重启后日志“startup oss ok”，就绪探针返回 ready=true